### PR TITLE
Separate tox environment setup from the test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           tox -vv --notest -e ${{ matrix.task.tox }}-${{ matrix.python.tox }}-${{ matrix.qt_library.tox }}
       - name: Test
         run: |
-          tox -vv -e ${{ matrix.task.tox }}-${{ matrix.python.tox }}-${{ matrix.qt_library.tox }}
+          tox -e ${{ matrix.task.tox }}-${{ matrix.python.tox }}-${{ matrix.qt_library.tox }}
       - name: Coverage Processing
         if: matrix.task.coverage
         run: |
@@ -169,7 +169,7 @@ jobs:
           tox -vv --notest -e ${{ matrix.task.tox }}
       - name: Test
         run: |
-          tox -vv -e ${{ matrix.task.tox }}
+          tox -e ${{ matrix.task.tox }}
 
   all:
     name: All

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,14 @@ jobs:
           apt-get install --yes libgl1 libgl1-mesa-dev xvfb x11-utils libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
       - uses: altendky/QTBUG-88688-libxcb-util@v2
         if: matrix.os.matrix == 'linux'
-      - name: Install
+      - name: Install tox
         run: |
           pip install --upgrade pip setuptools wheel
           pip install --upgrade tox
       - uses: twisted/python-info-action@v1.0.1
+      - name: Setup tox environment
+        run: |
+          tox -vv --notest -e ${{ matrix.task.tox }}-${{ matrix.python.tox }}-${{ matrix.qt_library.tox }}
       - name: Test
         run: |
           tox -vv -e ${{ matrix.task.tox }}-${{ matrix.python.tox }}-${{ matrix.qt_library.tox }}
@@ -156,16 +159,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install
+      - name: Install tox
         run: |
-          pip install --upgrade pip setuptools wheel
-          pip install tox
           pip install --upgrade pip setuptools wheel
           pip install --upgrade tox
       - uses: twisted/python-info-action@v1.0.1
+      - name: Setup tox environment
+        run: |
+          tox -vv --notest -e ${{ matrix.task.tox }}
       - name: Test
         run: |
-          tox -v -e ${{ matrix.task.tox }}
+          tox -vv -e ${{ matrix.task.tox }}
 
   all:
     name: All


### PR DESCRIPTION
This just provides better feedback on individual activity timing and makes for less installation boilerplate to scroll through when looking at the tests.