### PR TITLE
Expose CODECOV_TOKEN to in-repo builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
           tox -e ${{ matrix.task.tox }}-${{ matrix.python.tox }}-${{ matrix.qt_library.tox }}
       - name: Coverage Processing
         if: matrix.task.coverage
+        env:
+          CODECOV_TOKEN: secrets.CODECOV_TOKEN
         run: |
           mkdir coverage_reports
           cp .coverage "coverage_reports/coverage.${{ env.JOB_NAME }}"
@@ -263,6 +265,8 @@ jobs:
           tox -e test-frozen-${{ matrix.qt_library.tox }}
       - name: Coverage Processing
         if: matrix.task.coverage
+        env:
+          CODECOV_TOKEN: secrets.CODECOV_TOKEN
         run: |
           mkdir coverage_reports
           cp .coverage "coverage_reports/coverage.${{ env.JOB_NAME }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Coverage Processing
         if: matrix.task.coverage
         env:
-          CODECOV_TOKEN: secrets.CODECOV_TOKEN
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           mkdir coverage_reports
           cp .coverage "coverage_reports/coverage.${{ env.JOB_NAME }}"
@@ -266,7 +266,7 @@ jobs:
       - name: Coverage Processing
         if: matrix.task.coverage
         env:
-          CODECOV_TOKEN: secrets.CODECOV_TOKEN
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           mkdir coverage_reports
           cp .coverage "coverage_reports/coverage.${{ env.JOB_NAME }}"

--- a/tox.ini
+++ b/tox.ini
@@ -98,6 +98,7 @@ allowlist_externals =
     curl
 passenv =
     CI
+    CODECOV_TOKEN
     GITHUB_*
 commands =
     curl --output codecov.sh https://codecov.io/bash


### PR DESCRIPTION
Might help with https://github.com/altendky/ssst/issues/38

Note that secrets do not get exposed to out-of-repository PRs.  We'll see if this is sufficient to sort out the issue.  If not, we can just put the token in the repository.  Bad actors uploading bogus coverage reports isn't the most scary attack vector ever.