### PR TITLE
Follow redirects when downloading codecov bash script

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -100,7 +100,7 @@ passenv =
     CI
     GITHUB_*
 commands =
-    curl --output codecov.sh https://codecov.io/bash
+    curl --location --output codecov.sh https://codecov.io/bash
     bash codecov.sh -Z -n "{env:JOB_NAME:unspecified}"
 
 [testenv:freeze-pyinstaller-{pyqt5,pyside2}]


### PR DESCRIPTION
The `--location` requests following of redirects.