### PR TITLE
Reduce QTrio version repetition

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,6 @@ install_requires =
     attrs ~=20.3.0
     click ~=7.1
     pymodbus @ https://github.com/altendky/pymodbus/archive/83bf25071bdf56ece257e2e113a63dccf6bd692a.zip
-    # TODO: Should not need to duplicate the QTrio version info down below.
-    #       https://github.com/pypa/pip/issues/9437
     # >=0.4.1 for https://github.com/altendky/qtrio/pull/211
     qtrio ~=0.4.1
     # TODO: Uncomment whenever we get to using sundog here.
@@ -37,14 +35,10 @@ pyqt5 =
     # !=5.15.4 for https://github.com/altendky/ssst/issues/47
     #     it only really applies to macOS but i wasn't able to restrict to that
     pyqt5 ~=5.15, !=5.15.4
-    # TODO: Should not need to duplicate the QTrio version info from above.
-    #       https://github.com/pypa/pip/issues/9437
-    qtrio[pyqt5] ~=0.4.1
+    qtrio[pyqt5]
 pyside2 =
     pyside2 ~=5.15
-    # TODO: Should not need to duplicate the QTrio version info from above.
-    #       https://github.com/pypa/pip/issues/9437
-    qtrio[pyside2] ~=0.4.1
+    qtrio[pyside2]
 both =
     %(pyqt5)s
     %(pyside2)s

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ install_command =
     # to describe the acceptable version range.
     python -m pip install {opts} {packages} --constraint {toxinidir}/constraints/test.txt
 setenv =
-    VIRTUALENV_PIP = 21.0.1
+    VIRTUALENV_PIP = 21.1.3
     VIRTUALENV_DOWNLOAD = true
 
 [testenv:test-py3{6,7,8,9}-{pyqt5,pyside2}]


### PR DESCRIPTION
Shouldn't be needed in pip >= 21.1.

https://github.com/pypa/pip/issues/9437
https://github.com/pypa/pip/issues/8785
https://github.com/pypa/pip/pull/9775

This is still broken in 21.1.3 but it seems to be fixed at least as of https://github.com/pypa/pip/commit/f37fc4c3e80acea52444ec34db3bdfffab9d9618 (https://github.com/pypa/pip/issues/9437#issuecomment-874339427).

Draft for:
- [ ] Next pip release